### PR TITLE
Ald-37-use-name-matching-instead-of-aldi-g

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,28 +2,31 @@ import { addMonths, subMonths } from "date-fns";
 import DashboardMessages from "~/components/dashboard/DashboardMessages";
 import RecentShifts from "~/components/dashboard/RecentShifts";
 import UpcomingShifts from "~/components/dashboard/UpcomingShifts";
+import { getUser } from "~/lib/auth/utils";
 import { parseGmailMessage } from "~/lib/email/utils";
 import { api } from "~/trpc/server";
 
 export default async function Home() {
   const events = await api.events.getEvents.query({
-    start: subMonths(new Date(), 1),
+    start: subMonths(new Date(), 12),
     end: addMonths(new Date(), 1),
   });
   const gmailResponses = await api.messages.getEvents.query();
   const messages = gmailResponses.map((message) => {
     return parseGmailMessage(message);
   });
+  const user = await getUser();
+  if (!user) return null;
 
   return (
     <div className="flex max-h-full flex-col px-8 pt-3">
       <div className="grow-[2]">
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-        <UpcomingShifts events={events} />
+        <UpcomingShifts events={events} user={user} />
       </div>
       <div className="flex grow gap-4 overflow-y-auto p-2">
         <DashboardMessages messages={messages} />
-        <RecentShifts events={events} />
+        <RecentShifts events={events} user={user} />
       </div>
     </div>
   );

--- a/src/app/shifts/_components/MyShifts.tsx
+++ b/src/app/shifts/_components/MyShifts.tsx
@@ -1,95 +1,100 @@
 import {
-  Card,
-  CardDescription,
-  CardHeader,
-  CardTitle,
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
 } from "~/components/ui/card";
 import { TabsContent } from "~/components/ui/tabs";
 import { groupEventsByDay } from "~/lib/gcal/utils";
 
-import { currentUser } from "@clerk/nextjs";
-import { type User } from "@clerk/nextjs/server";
 import Link from "next/link";
-import { contactToSearchNames, getUser, nameToContact } from "~/lib/auth/utils";
 import { inEvent, roleInEvent, timeRangeString } from "~/lib/events/utils";
 import type { EventsOutput } from "~/server/api/routers/events";
 
 type CmoEvent = EventsOutput["getEvents"][0];
 type OverviewProps = {
-  events: CmoEvent[];
+    events: CmoEvent[];
+    searchNames: string[];
 };
 
 type DaySectionProps = {
-  day: string;
-  events: CmoEvent[];
-  names: string[];
+    day: string;
+    events: CmoEvent[];
+    searchNames: string[];
 };
 
 type ShiftCardProps = {
-  event: CmoEvent;
-  names: string[];
+    event: CmoEvent;
+    searchNames: string[];
 };
 
-const DaySection: React.FC<DaySectionProps> = ({ day, events, names }) => {
-  return (
-    <div className="space-y-1">
-      <h3 className="text-lg font-semibold">{day}</h3>
-      {events.map((event) => (
-        <ShiftCard key={event.id} event={event} names={names} />
-      ))}
-    </div>
-  );
+const DaySection: React.FC<DaySectionProps> = ({
+    day,
+    events,
+    searchNames,
+}) => {
+    return (
+        <div className="space-y-1">
+            <h3 className="text-lg font-semibold">{day}</h3>
+            {events.map((event) => (
+                <ShiftCard
+                    key={event.id}
+                    event={event}
+                    searchNames={searchNames}
+                />
+            ))}
+        </div>
+    );
 };
 
-const ShiftCard: React.FC<ShiftCardProps> = ({ event, names }) => {
-  return (
-    <Card className="transition-all hover:scale-x-[1.01] hover:scale-y-105 hover:shadow-lg">
-      <Link href={`/shifts/${event.id}`} className="block h-full w-full">
-        <CardHeader className="space-y-0 px-4 py-2.5">
-          {!event.cancelled ? (
-            <CardTitle className="text-lg">{`${event.title}`}</CardTitle>
-          ) : (
-            <CardTitle className="text-lg text-red-900 line-through">{`${event.title}`}</CardTitle>
-          )}
-          <CardDescription>
-            <b className="font-semibold">{`${roleInEvent(event, names)}`}</b>
-            {`${
-              event.location !== undefined ? ` - ${event.location} - ` : ""
-            }${timeRangeString(event)}`}
-          </CardDescription>
-        </CardHeader>
-      </Link>
-    </Card>
-  );
+const ShiftCard: React.FC<ShiftCardProps> = ({ event, searchNames }) => {
+    return (
+        <Card className="transition-all hover:scale-x-[1.01] hover:scale-y-105 hover:shadow-lg">
+            <Link href={`/shifts/${event.id}`} className="block h-full w-full">
+                <CardHeader className="space-y-0 px-4 py-2.5">
+                    {!event.cancelled ? (
+                        <CardTitle className="text-lg">{`${event.title}`}</CardTitle>
+                    ) : (
+                        <CardTitle className="text-lg text-red-900 line-through">{`${event.title}`}</CardTitle>
+                    )}
+                    <CardDescription>
+                        <b className="font-semibold">{`${roleInEvent(
+                            event,
+                            searchNames,
+                        )}`}</b>
+                        {`${
+                            event.location !== undefined
+                                ? ` - ${event.location} - `
+                                : ""
+                        }${timeRangeString(event)}`}
+                    </CardDescription>
+                </CardHeader>
+            </Link>
+        </Card>
+    );
 };
 
-const MyShifts: React.FC<OverviewProps> = async ({ events }) => {
-  // const user = await getUser();
-  const user = await currentUser();
-  if (!user) return null;
-  const contact = nameToContact(user.firstName + " " + user.lastName);
-  if (!contact) return null;
-  const names = contactToSearchNames(contact);
-  const myEvents = groupEventsByDay(
-    events.filter((event) => inEvent(event, names)),
-  );
-  return (
-    <TabsContent value="myShifts" className="space-y-4">
-      <div className="mx-2 mb-5 flex flex-col gap-2 ">
-        <h3 className="text-3xl font-bold">Your Shifts</h3>
-        {myEvents.map((day) => {
-          return (
-            <DaySection
-              key={day.day}
-              day={day.day}
-              events={day.events}
-              names={names}
-            />
-          );
-        })}
-      </div>
-    </TabsContent>
-  );
+const MyShifts: React.FC<OverviewProps> = async ({ events, searchNames }) => {
+    const myEvents = groupEventsByDay(
+        events.filter((event) => inEvent(event, searchNames)),
+    );
+    return (
+        <TabsContent value="myShifts" className="space-y-4">
+            <div className="mx-2 mb-5 flex flex-col gap-2 ">
+                <h3 className="text-3xl font-bold">Your Shifts</h3>
+                {myEvents.map((day) => {
+                    return (
+                        <DaySection
+                            key={day.day}
+                            day={day.day}
+                            events={day.events}
+                            searchNames={searchNames}
+                        />
+                    );
+                })}
+            </div>
+        </TabsContent>
+    );
 };
 
 export default MyShifts;

--- a/src/app/shifts/_components/MyShifts.tsx
+++ b/src/app/shifts/_components/MyShifts.tsx
@@ -7,7 +7,10 @@ import {
 import { TabsContent } from "~/components/ui/tabs";
 import { groupEventsByDay } from "~/lib/gcal/utils";
 
+import { currentUser } from "@clerk/nextjs";
+import { type User } from "@clerk/nextjs/server";
 import Link from "next/link";
+import { contactToSearchNames, getUser, nameToContact } from "~/lib/auth/utils";
 import { inEvent, roleInEvent, timeRangeString } from "~/lib/events/utils";
 import type { EventsOutput } from "~/server/api/routers/events";
 
@@ -19,24 +22,26 @@ type OverviewProps = {
 type DaySectionProps = {
   day: string;
   events: CmoEvent[];
+  names: string[];
 };
 
 type ShiftCardProps = {
   event: CmoEvent;
+  names: string[];
 };
 
-const DaySection: React.FC<DaySectionProps> = ({ day, events }) => {
+const DaySection: React.FC<DaySectionProps> = ({ day, events, names }) => {
   return (
     <div className="space-y-1">
       <h3 className="text-lg font-semibold">{day}</h3>
       {events.map((event) => (
-        <ShiftCard key={event.id} event={event} />
+        <ShiftCard key={event.id} event={event} names={names} />
       ))}
     </div>
   );
 };
 
-const ShiftCard: React.FC<ShiftCardProps> = ({ event }) => {
+const ShiftCard: React.FC<ShiftCardProps> = ({ event, names }) => {
   return (
     <Card className="transition-all hover:scale-x-[1.01] hover:scale-y-105 hover:shadow-lg">
       <Link href={`/shifts/${event.id}`} className="block h-full w-full">
@@ -47,10 +52,7 @@ const ShiftCard: React.FC<ShiftCardProps> = ({ event }) => {
             <CardTitle className="text-lg text-red-900 line-through">{`${event.title}`}</CardTitle>
           )}
           <CardDescription>
-            <b className="font-semibold">{`${roleInEvent(
-              event,
-              "Aldi G.",
-            )}`}</b>
+            <b className="font-semibold">{`${roleInEvent(event, names)}`}</b>
             {`${
               event.location !== undefined ? ` - ${event.location} - ` : ""
             }${timeRangeString(event)}`}
@@ -61,16 +63,29 @@ const ShiftCard: React.FC<ShiftCardProps> = ({ event }) => {
   );
 };
 
-const MyShifts: React.FC<OverviewProps> = ({ events }) => {
+const MyShifts: React.FC<OverviewProps> = async ({ events }) => {
+  // const user = await getUser();
+  const user = await currentUser();
+  if (!user) return null;
+  const contact = nameToContact(user.firstName + " " + user.lastName);
+  if (!contact) return null;
+  const names = contactToSearchNames(contact);
   const myEvents = groupEventsByDay(
-    events.filter((event) => inEvent(event, "Aldi G.")),
+    events.filter((event) => inEvent(event, names)),
   );
   return (
     <TabsContent value="myShifts" className="space-y-4">
       <div className="mx-2 mb-5 flex flex-col gap-2 ">
         <h3 className="text-3xl font-bold">Your Shifts</h3>
         {myEvents.map((day) => {
-          return <DaySection key={day.day} day={day.day} events={day.events} />;
+          return (
+            <DaySection
+              key={day.day}
+              day={day.day}
+              events={day.events}
+              names={names}
+            />
+          );
         })}
       </div>
     </TabsContent>

--- a/src/app/shifts/_components/TabContainer.tsx
+++ b/src/app/shifts/_components/TabContainer.tsx
@@ -2,57 +2,59 @@
 
 import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
 
+import { usePathname, useRouter } from "next/navigation";
+import AllShifts from "~/app/shifts/_components/AllShifts";
 import MyShifts from "~/app/shifts/_components/MyShifts";
 import OpenShifts from "~/app/shifts/_components/OpenShifts";
-import AllShifts from "~/app/shifts/_components/AllShifts";
-import { type Event } from "~/lib/events/utils";
 import SearchBar from "~/app/shifts/_components/SearchBar";
-import { usePathname, useRouter } from "next/navigation";
+import { type Event } from "~/lib/events/utils";
 
 type TabContainerProps = {
-  events: Event[];
-  searchParams: Record<string, string | undefined>;
+    events: Event[];
+    searchParams: Record<string, string | undefined>;
+    searchNames: string[];
 };
 
 const TabContainer: React.FC<TabContainerProps> = ({
-  events,
-  searchParams,
+    events,
+    searchParams,
+    searchNames,
 }) => {
-  const router = useRouter();
-  const pathname = usePathname();
-  const tab = searchParams.shifts ?? "myShifts";
-  const handleTabChange = (value: string) => {
-    searchParams.shifts = value;
-    const queryString = Object.entries(searchParams)
-      .map(([key, value]) =>
-        key && value
-          ? `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
-          : "",
-      )
-      .filter(Boolean)
-      .join("&");
-    const query = queryString ? `?${queryString}` : "";
-    router.replace(`${pathname}${query}`);
-  };
-  return (
-    <Tabs
-      defaultValue={tab}
-      onValueChange={handleTabChange}
-      className="space-y-4 pb-2"
-    >
-      <div className="flex flex-col items-center justify-between gap-6 space-x-2 md:flex-row">
-        <TabsList>
-          <TabsTrigger value="myShifts">My Shifts</TabsTrigger>
-          <TabsTrigger value="openShifts">Open Shifts</TabsTrigger>
-          <TabsTrigger value="allShifts">All Shifts</TabsTrigger>
-        </TabsList>
-        <SearchBar searchParams={searchParams} />
-      </div>
-      <MyShifts events={events} />
-      <OpenShifts events={events} />
-      <AllShifts events={events} />
-    </Tabs>
-  );
+    const router = useRouter();
+    const pathname = usePathname();
+    const tab = searchParams.shifts ?? "myShifts";
+    const handleTabChange = (value: string) => {
+        searchParams.shifts = value;
+        const queryString = Object.entries(searchParams)
+            .map(([key, value]) =>
+                key && value
+                    ? `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+                    : "",
+            )
+            .filter(Boolean)
+            .join("&");
+        const query = queryString ? `?${queryString}` : "";
+        router.replace(`${pathname}${query}`);
+    };
+    return (
+        <Tabs
+            defaultValue={tab}
+            onValueChange={handleTabChange}
+            className="space-y-4 pb-2"
+        >
+            <div className="flex flex-col items-center justify-between gap-6 space-x-2 md:flex-row">
+                <TabsList>
+                    <TabsTrigger value="myShifts">My Shifts</TabsTrigger>
+                    <TabsTrigger value="openShifts">Open Shifts</TabsTrigger>
+                    <TabsTrigger value="allShifts">All Shifts</TabsTrigger>
+                </TabsList>
+                <SearchBar searchParams={searchParams} />
+            </div>
+            <MyShifts events={events} searchNames={searchNames} />
+            <OpenShifts events={events} />
+            <AllShifts events={events} />
+        </Tabs>
+    );
 };
 
 export default TabContainer;

--- a/src/app/shifts/page.tsx
+++ b/src/app/shifts/page.tsx
@@ -3,6 +3,7 @@ import { api } from "~/trpc/server";
 import { addMonths } from "date-fns";
 import { isSearched } from "~/lib/events/utils";
 
+import { getUser } from "~/lib/auth/utils";
 import ShiftDatePicker from "./_components/ShiftDatePicker";
 import TabContainer from "./_components/TabContainer";
 
@@ -16,16 +17,18 @@ const Shifts = async ({
   const start = new Date(searchParams.start);
   const end = new Date(searchParams.end);
   const data = await api.events.getEvents.query({ start, end });
+  const user = await getUser();
+  if (!user) return null;
   const events = data.filter((event) => {
-    return isSearched(event, searchParams, "Aldi G.");
+    return isSearched(event, searchParams, user.searchNames);
   });
+  console.log(events);
 
   return (
     <div className="flex-1 space-y-4 p-5 pt-6">
       <div className="flex justify-between">
         <h1 className="text-3xl font-semibold">Shifts</h1>
         <ShiftDatePicker searchParams={searchParams} />
-        {/* <div className="flex items-center space-x-2 rounded border bg-white px-4 py-2">{`${start.toLocaleDateString()} - ${end.toLocaleDateString()}`}</div> */}
       </div>
       <TabContainer events={events} searchParams={searchParams} />
     </div>

--- a/src/app/shifts/page.tsx
+++ b/src/app/shifts/page.tsx
@@ -8,31 +8,35 @@ import ShiftDatePicker from "./_components/ShiftDatePicker";
 import TabContainer from "./_components/TabContainer";
 
 const Shifts = async ({
-  searchParams,
+    searchParams,
 }: {
-  searchParams: Record<string, string | undefined>;
+    searchParams: Record<string, string | undefined>;
 }) => {
-  searchParams.start = searchParams.start ?? new Date().toISOString();
-  searchParams.end = searchParams.end ?? addMonths(new Date(), 3).toISOString();
-  const start = new Date(searchParams.start);
-  const end = new Date(searchParams.end);
-  const data = await api.events.getEvents.query({ start, end });
-  const user = await getUser();
-  if (!user) return null;
-  const events = data.filter((event) => {
-    return isSearched(event, searchParams, user.searchNames);
-  });
-  console.log(events);
+    searchParams.start = searchParams.start ?? new Date().toISOString();
+    searchParams.end =
+        searchParams.end ?? addMonths(new Date(), 3).toISOString();
+    const start = new Date(searchParams.start);
+    const end = new Date(searchParams.end);
+    const data = await api.events.getEvents.query({ start, end });
+    const user = await getUser();
+    if (!user) return null;
+    const events = data.filter((event) => {
+        return isSearched(event, searchParams, user.searchNames);
+    });
 
-  return (
-    <div className="flex-1 space-y-4 p-5 pt-6">
-      <div className="flex justify-between">
-        <h1 className="text-3xl font-semibold">Shifts</h1>
-        <ShiftDatePicker searchParams={searchParams} />
-      </div>
-      <TabContainer events={events} searchParams={searchParams} />
-    </div>
-  );
+    return (
+        <div className="flex-1 space-y-4 p-5 pt-6">
+            <div className="flex justify-between">
+                <h1 className="text-3xl font-semibold">Shifts</h1>
+                <ShiftDatePicker searchParams={searchParams} />
+            </div>
+            <TabContainer
+                events={events}
+                searchParams={searchParams}
+                searchNames={user.searchNames}
+            />
+        </div>
+    );
 };
 
 export default Shifts;

--- a/src/components/dashboard/DashboardShiftCard.tsx
+++ b/src/components/dashboard/DashboardShiftCard.tsx
@@ -1,3 +1,4 @@
+import type { User } from "@clerk/nextjs/server";
 import Link from "next/link";
 import {
   longTimeRangeString,
@@ -8,9 +9,16 @@ import { Card, CardContent } from "../ui/card";
 
 type ShiftCardProps = {
   event: Event;
+  user: namedUser;
 };
+interface namedUser extends User {
+  searchNames: string[];
+}
 
-const DashboardShiftCard: React.FC<ShiftCardProps> = async ({ event }) => {
+const DashboardShiftCard: React.FC<ShiftCardProps> = async ({
+  event,
+  user,
+}) => {
   return (
     <Card
       className="relative inline-flex h-28 w-72 snap-start items-start justify-start gap-4 rounded-lg border border-purple-900/10
@@ -19,7 +27,7 @@ const DashboardShiftCard: React.FC<ShiftCardProps> = async ({ event }) => {
       <CardContent className="pl-1">
         <div className="inline-flex flex-col items-start justify-start gap-1 pr-10">
           <div className="w-[200px] text-sm font-semibold leading-tight text-slate-900">
-            {roleInEvent(event, "Aldi G.")}
+            {roleInEvent(event, user.searchNames)}
           </div>
           <div className="w-[200px] text-[11px] font-normal leading-tight text-slate-900">
             {event.title}

--- a/src/components/dashboard/RecentShifts.tsx
+++ b/src/components/dashboard/RecentShifts.tsx
@@ -1,3 +1,4 @@
+import type { User } from "@clerk/nextjs/server";
 import { isAfter } from "date-fns";
 import { getUser } from "~/lib/auth/utils";
 import { inEvent, type Event } from "~/lib/events/utils";
@@ -5,15 +6,20 @@ import DashboardShiftCard from "./DashboardShiftCard";
 
 type Props = {
   events: Event[];
+  user: namedUser;
 };
 
-const RecentShifts = async ({ events }: Props) => {
+interface namedUser extends User {
+  searchNames: string[];
+}
+
+const RecentShifts = async ({ events, user }: Props) => {
   const res = await getUser();
   if (!res) return null;
 
   const recentShifts = events
     .filter((event) => {
-      return inEvent(event, "Aldi G.") && isAfter(new Date(), event.end);
+      return inEvent(event, user.searchNames) && isAfter(new Date(), event.end);
     })
     .reverse();
   if (recentShifts.length === 0) return null;
@@ -22,7 +28,9 @@ const RecentShifts = async ({ events }: Props) => {
       <h3 className="block text-xl font-normal">Recent Shifts</h3>
       <div className="flex snap-y snap-mandatory scroll-p-0.5 flex-col gap-1 overflow-y-auto px-2 pb-2">
         {recentShifts.map((event) => {
-          return <DashboardShiftCard key={event.id} event={event} />;
+          return (
+            <DashboardShiftCard key={event.id} event={event} user={user} />
+          );
         })}
       </div>
     </div>

--- a/src/components/dashboard/UpcomingShifts.tsx
+++ b/src/components/dashboard/UpcomingShifts.tsx
@@ -1,3 +1,4 @@
+import type { User } from "@clerk/nextjs/server";
 import { isAfter } from "date-fns";
 import Link from "next/link";
 import { inEvent } from "~/lib/events/utils";
@@ -6,20 +7,24 @@ import DashboardShiftCard from "./DashboardShiftCard";
 
 type Props = {
   events: EventsOutput["getEvents"];
+  user: namedUser;
 };
+interface namedUser extends User {
+  searchNames: string[];
+}
 
-const UpcomingShifts = ({ events }: Props) => {
+const UpcomingShifts = ({ events, user }: Props) => {
   const upcomingShifts = events.filter((event) => {
-    return inEvent(event, "Aldi G.") && isAfter(event.start, new Date());
+    return inEvent(event, user.searchNames) && isAfter(event.start, new Date());
   });
   if (upcomingShifts.length === 0) {
     return (
-      <div className="mt-4 w-full rounded-lg bg-card border-card-foreground/35 border p-4 shadow">
+      <div className="mt-4 w-full rounded-lg border border-card-foreground/35 bg-card p-4 shadow">
         <h3 className="text-base">
           No upcoming shifts, go to{" "}
           <Link
             href={"/shifts?shifts=allShifts"}
-            className="font-semibold text-purple-900 dark:text-purple-600 underline"
+            className="font-semibold text-purple-900 underline dark:text-purple-600"
           >
             shifts
           </Link>{" "}
@@ -33,7 +38,9 @@ const UpcomingShifts = ({ events }: Props) => {
       <h3 className="text-xl font-normal">Upcoming Shifts</h3>
       <div className="flex snap-x snap-mandatory scroll-p-4 gap-5 overflow-x-auto pb-2">
         {upcomingShifts.map((event) => {
-          return <DashboardShiftCard key={event.id} event={event} />;
+          return (
+            <DashboardShiftCard key={event.id} event={event} user={user} />
+          );
         })}
       </div>
     </div>

--- a/src/lib/const/contacts.js
+++ b/src/lib/const/contacts.js
@@ -4,394 +4,454 @@ export const contacts = [
     lastName: "Abaci",
     cellPhone: "(678)231-4483",
     emailAddress: "devrimabaci2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Sheyla",
     lastName: "Adaya",
     cellPhone: "(224)334-4712",
     emailAddress: "sheylaadaya2024@u.northwestern.edu",
+    altNames:"Shayla"
   },
   {
     firstName: "Lillian",
     lastName: "Ali",
     cellPhone: "(937)286-7767",
     emailAddress: "lillianali2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Mariama",
     lastName: "Bah",
     cellPhone: "(224)428-7873",
     emailAddress: "mariamabah2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Stewart",
     lastName: "Bridgeforth",
     cellPhone: "(703)470-5144",
     emailAddress: "stewartbridgeforth2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Kailyn",
     lastName: "Brown",
     cellPhone: "(470)385-7539",
     emailAddress: "kailynbrown2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Anna",
     lastName: "Castagnaro",
     cellPhone: "(321)317-1089",
     emailAddress: "annacastagnaro2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Jason",
     lastName: "Chen",
     cellPhone: "(781)952-9214",
     emailAddress: "jasonchen2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Yolanda",
     lastName: "Chen",
     cellPhone: "(626)362-0418",
     emailAddress: "yolandachen2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "James",
     lastName: "Chou",
     cellPhone: "(929)316-4953",
     emailAddress: "yu-tienchou2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Chanelle",
     lastName: "Chu",
     cellPhone: "(669)208-8745",
     emailAddress: "chanellechu2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Filip",
     lastName: "Czarkowski",
     cellPhone: "(773)895-0714",
     emailAddress: "filipczarkowski2022@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Ellen",
     lastName: "Darmstadter",
     cellPhone: "(608)239-6227",
     emailAddress: "ellendarmstadter2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Sophie",
     lastName: "Denhard",
     cellPhone: "(206)450-8197",
     emailAddress: "sophiedenhard2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Ashwat",
     lastName: "Dhamotharan",
     cellPhone: "(248)775-9600",
     emailAddress: "ashwatdhamotharan2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Leilani",
     lastName: "Diaz",
     cellPhone: "(832)544-6509",
     emailAddress: "leilanidiaz2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Aldiery",
     lastName: "Gonzalez",
     cellPhone: "(407)867-1186",
     emailAddress: "aldierygonzalez2024@u.northwestern.edu",
+    altNames:"Aldi"
   },
   {
     firstName: "Spencer",
     lastName: "Guy",
     cellPhone: "(615)686-9826",
     emailAddress: "spencerguy2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Lily",
     lastName: "Hoyt",
     cellPhone: "(978)808-3120",
     emailAddress: "lilyhoyt2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Scott",
     lastName: "Hwang",
     cellPhone: "(650)670-8220",
     emailAddress: "scotthwang2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Sophia",
     lastName: "Jedziniak",
     cellPhone: "(630)383-8599",
     emailAddress: "sophiajedziniak2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Ian",
     lastName: "Jeon",
     cellPhone: "(917)745-7871",
     emailAddress: "ianjeon2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Hyeyun",
     lastName: "Jeong",
     cellPhone: "(571)523-6575",
     emailAddress: "hyeyunjeong2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Nicholas",
     lastName: "Kapp",
     cellPhone: "(331)575-4944",
     emailAddress: "nicholaskapp2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Ethan",
     lastName: "Karas",
     cellPhone: "(914)323-8530",
     emailAddress: "ethankaras2019@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Daniel",
     lastName: "Kinney",
     cellPhone: "(585)200-6578",
     emailAddress: "danielkinney2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Soraya",
     lastName: "Koblence",
     cellPhone: "(917)209-9554",
     emailAddress: "sorayakoblence2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Oliver",
     lastName: "Koenig",
     cellPhone: "(646)599-0323",
     emailAddress: "oliverkoenig2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "James",
     lastName: "La Fayette",
     cellPhone: "(813)347-1840",
     emailAddress: "Jameslafayette2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Alexander",
     lastName: "Lake",
     cellPhone: "(415)996-8554",
     emailAddress: "alexlake2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Jiho",
     lastName: "Lee",
     cellPhone: "(241)846-0420",
     emailAddress: "jiholee2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Brian",
     lastName: "Lin",
     cellPhone: "(909)996-8837",
     emailAddress: "brianlin2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Mercy",
     lastName: "Olayiwola",
     cellPhone: "(860)518-8053",
     emailAddress: "rjolayiwola2023@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Kevin",
     lastName: "Opeña",
     cellPhone: "(847)830-1839",
     emailAddress: "kevinopena2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Sebastian",
     lastName: "Ortiz",
     cellPhone: "(872)292-2693",
     emailAddress: "sebastianrrtiz2023@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Freya",
     lastName: "Ou",
     cellPhone: "(224)714-7942",
     emailAddress: "freyaou2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Ryan",
     lastName: "Payne",
     cellPhone: "(571)320-7536",
     emailAddress: "ryanpayne2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Eliza",
     lastName: "Reimold",
     cellPhone: "(978)237-2669",
     emailAddress: "elizareimold2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Jeffrey",
     lastName: "Ryan",
     cellPhone: "(615)569-8723",
     emailAddress: "jeffreyryan2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Angel",
     lastName: "Salinas",
     cellPhone: "(346)932-9392",
     emailAddress: "angelsalinas2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Pablo",
     lastName: "Schnelle",
     cellPhone: "(832)540-5021",
     emailAddress: "pabloschnelle2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Claire",
     lastName: "Shen",
     cellPhone: "(614)356-0536",
     emailAddress: "claireshen2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Chele",
     lastName: "Shuart",
     cellPhone: "(989)254-3451",
     emailAddress: "chelewynneshuart2023@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Ann",
     lastName: "Slivken",
     cellPhone: "(847)736-3447",
     emailAddress: "annslivken2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Jackson",
     lastName: "Spellman",
     cellPhone: "(561)603-3834",
     emailAddress: "jacksonspellman2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Lauren",
     lastName: "Tan",
     cellPhone: "(301)648-4167",
     emailAddress: "laurentan2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Emma",
     lastName: "Truong",
     cellPhone: "(773)754-9361",
     emailAddress: "emmatruong2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Julianna",
     lastName: "Wang",
     cellPhone: "(980)259-8081",
     emailAddress: "juliannawang2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Serge",
     lastName: "Wen",
     cellPhone: "(773)681-6185",
     emailAddress: "sergewen2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Haylie",
     lastName: "Wu",
     cellPhone: "(669)264-8245",
     emailAddress: "hayliewu2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Elliott",
     lastName: "Yoon",
     cellPhone: "(440)840-8549",
     emailAddress: "elliottyoon2025@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Kyle",
     lastName: "Yuen",
     cellPhone: "(510)683-1967",
     emailAddress: "kyleyuen2026@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Alina",
     lastName: "Zhang",
     cellPhone: "(773)290-4697",
     emailAddress: "alinazhang2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Joshua",
     lastName: "Zhuang",
     cellPhone: "(561)631-7583",
     emailAddress: "joshuazhuang2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Samantha",
     lastName: "Bittle",
     cellPhone: "(443)752-5263",
     emailAddress: "scbittle@gmail.com",
+    altNames:""
   },
   {
     firstName: "Rachel",
     lastName: "Frazier",
     cellPhone: "(630)862-9715",
     emailAddress: "racfrazier1@gmail.com",
+    altNames:""
   },
   {
     firstName: "Michelle",
     lastName: "Guzman",
     cellPhone: "(956)341-4216",
     emailAddress: "michelleguzman2024@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Sean",
     lastName: "Keenan",
     cellPhone: "(719)351-5839",
     emailAddress: "keenanrecording@gmail.com",
+    altNames:""
   },
   {
     firstName: "Nick",
     lastName: "Lin",
     cellPhone: "(847)347-9510",
     emailAddress: "nick@peckhammp.com",
+    altNames:""
   },
   {
     firstName: "Matt",
     lastName: "Peckham",
     cellPhone: "(218)269-0626",
     emailAddress: "matt@peckhammp.com",
+    altNames:""
   },
   {
     firstName: "Amanda",
     lastName: "Swanson",
     cellPhone: "(815)531-5267",
     emailAddress: "amandaswanson2020@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Michael",
     lastName: "Turner",
     cellPhone: "(312)459-8839",
     emailAddress: "michaelturner2023@u.northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Austin",
     lastName: "Williams",
     cellPhone: "(651)472-4739",
     emailAddress: "austingwilliamsmusic@gmail.com",
+    altNames:""
   },
   {
     firstName: "Bill",
     lastName: "Milgram",
     cellPhone: "(847)641-0155",
     emailAddress: "w-milgram@northwestern.edu",
+    altNames:""
   },
   {
     firstName: "Henry",
     lastName: "Stewart",
     cellPhone: "(574)326-9842",
     emailAddress: "henry.stewart@northwestern.edu",
+    altNames:""
   },
 ];
-
-export const alternateNames = {
-  aldi: "aldiery",
-  shayla: "sheyla",
-};

--- a/src/lib/events/utils.ts
+++ b/src/lib/events/utils.ts
@@ -11,16 +11,16 @@ export function getFilledShifts(event: Event) {
   return event.shifts.filter((shift) => shift.isFilled);
 }
 
-export function inEvent(event: Event, employeeName: string) {
+export function inEvent(event: Event, employeeNames: string[]) {
   for (const shift of event.shifts) {
-    if (shift.filledBy == employeeName) return true;
+    if (employeeNames.some((name) => name == shift.filledBy)) return true;
   }
   return false;
 }
 
-export function roleInEvent(event: Event, employeeName: string) {
+export function roleInEvent(event: Event, employeeNames: string[]) {
   for (const shift of event.shifts) {
-    if (shift.filledBy == employeeName) return shift.role;
+    if (employeeNames.some((name) => name == shift.filledBy)) return shift.role;
   }
   return false;
 }
@@ -28,10 +28,10 @@ export function roleInEvent(event: Event, employeeName: string) {
 export function isSearched(
   event: Event,
   searchParam: NextUrlSearchParams,
-  employeeName = "",
+  employeeNames = [""],
 ) {
   return (
-    hasSearchTerm(event, searchParam.search ?? null, employeeName) &&
+    hasSearchTerm(event, searchParam.search ?? null, employeeNames) &&
     hasLocationSearchTerm(event, searchParam.location ?? null)
   );
 }
@@ -39,10 +39,10 @@ export function isSearched(
 export function hasSearchTerm(
   event: Event,
   searchTerm: string | null,
-  employeeName = "",
+  employeeNames = [""],
 ) {
   if (searchTerm == null) return true;
-  const role = roleInEvent(event, employeeName);
+  const role = roleInEvent(event, employeeNames);
   if (event.title?.toLowerCase().includes(searchTerm.toLowerCase()))
     return true;
   if (event.location?.toLowerCase().includes(searchTerm.toLowerCase()))


### PR DESCRIPTION
Issue was that MyShifts is behind Client Boundary
I was avoiding using the string array because I might want the entire user, but it cant be passed from Server to Client component. This is because it was too complex
The solution that was causing problems was trying to use getUser in myShifts, which while not specifically a client component, is rendered by one.
This means it does not get access to the server component clerk functions.
Solution: prop drill the alternative Names/ searchNames array, which can be passed server to client